### PR TITLE
Replace Civicrm in views for Catalunya en Comú

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -13,8 +13,8 @@ ca:
         error: Hi ha hagut un error a l'hora de verificar el compte
         error_codes:
           '2001': Els paràmetres enviats són incorrectes
-          not-found: No s'ha trobat l'usuària a CiViCRM
-        explanation: Autorització mitjançant el compte de CiViCRM
+          not-found: No s'ha trobat l'usuària de Catalunya en Comú
+        explanation: Autorització mitjançant el compte de Catalunya en Comú
         fields:
           cn_member: Membre del Consell Nacional
           regional_scope: Àmbit Territorial
@@ -35,7 +35,7 @@ ca:
           role_choices:
             inscribed: Inscrita
             interested: Interessada
-        name: CiViCRM
+        name: Catalunya en Comú
       direct_verifications:
         name: Consell Nacional
         explanation: Verificació directa per al Consell Nacional
@@ -46,17 +46,17 @@ ca:
             no era "civicrm" tal com s'esperava.
           invalid_status: No us heu pogut verificar. La verificació OAuth2 ha fallat.
         invalid:
-          email_intro: La verificació CiViCRM ha fallat.
+          email_intro: La verificació amb Catalunya en Comú ha fallat.
           email_outro: Si us plau, poseu-vos en contacte amb el suport de la vostra
             plataforma per comprovar l'error que s'ha produït.
-          email_subject: No us heu pogut verificar amb CiViCRM.
-          notification_title: La verificació CiViCRM ha fallat.
+          email_subject: No us heu pogut verificar amb Catalunya en Comú.
+          notification_title: La verificació Catalunya en Comú ha fallat.
         ok:
-          email_intro: Us heu verificat correctament amb CiViCRM.
+          email_intro: Us heu verificat correctament amb Catalunya en Comú.
           email_outro: Ara podeu realitzar totes les accions que requereixin l'autorització
-            de CiViCRM.
-          email_subject: Us heu verificat amb CiViCRM.
-          notification_title: Us heu verificat correctament amb CiViCRM.
+            de Catalunya en Comú.
+          email_subject: Us heu verificat amb Catalunya en Comú.
+          notification_title: Us heu verificat correctament amb Catalunya en Comú.
     system:
       organizations:
         omniauth_settings:
@@ -69,6 +69,6 @@ ca:
       authorizations:
         first_login:
           actions:
-            civicrm: Verifica't amb el compte de CiViCRM
+            civicrm: Verifica't amb el compte de Catalunya en Comú
   forms:
     required_explanation: "* Els camps obligatoris estan marcats amb un asterisc"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,0 @@
----
-en:
-  hello: Hello world

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -10,8 +10,8 @@ es:
         error: Ha ocurrido un error a la hora de verificar la cuenta
         error_codes:
           '2001': Los parámetros enviados son incorrectos
-          not-found: No se ha encontrado la usuario en CiViCRM
-        explanation: Autorización mediante la cuenta de CiViCRM
+          not-found: No se ha encontrado la usuaria en Catalunya en Comú
+        explanation: Autorización mediante la cuenta de Catalunya en Comú
         fields:
           cn_member: Miembro del Consejo Nacional
           regional_scope: Ámbito Territorial
@@ -32,7 +32,7 @@ es:
           role_choices:
             inscribed: Inscrita
             interested: Interesada
-        name: CiViCRM
+        name: Catalunya en Comú
       direct_verifications:
         explanation: Verificación directa para el Consejo Nacional
         name: Consejo Nacional
@@ -44,17 +44,17 @@ es:
           invalid_status: No se os ha podido verificar. La verificación OAuth2 ha
             fallado.
         invalid:
-          email_intro: La verificación con CiViCRM ha fallado.
+          email_intro: La verificación con Catalunya en Comú ha fallado.
           email_outro: Por favor, poneos en contacto con el soporte de vuestra plataforma
             para comprobar el error que ha ocurrido.
-          email_subject: No se os ha podido verificar con CiViCRM.
-          notification_title: La verificación con CiViCRM ha fallado.
+          email_subject: No se os ha podido verificar con Catalunya en Comú.
+          notification_title: La verificación con Catalunya en Comú ha fallado.
         ok:
-          email_intro: Te has verificado correctamente mediante CiViCRM.
+          email_intro: Te has verificado correctamente con Catalunya en Comú.
           email_outro: A partir de ahora ya puedes participar en todas aquellas acciones
-            que requieran autorización expresa mediante este método.
-          email_subject: Te has verificado mediante CiViCRM.
-          notification_title: Te has verificado mediante CiViCRM correctamente.
+            que requieran la autorización de Catalunya en Comú.
+          email_subject: Te has verificado con Catalunya en Comú.
+          notification_title: Te has verificado correctamente con Catalunya en Comú.
     system:
       organizations:
         omniauth_settings:
@@ -63,5 +63,10 @@ es:
             client_secret: Secreto de cliente
             site: URL del servidor de Omniauth
           enabled_by_default: Activado por defecto
+        verifications:
+          authorizations:
+            first_login:
+              actions:
+                civicrm: Verifícate con tu cuenta de Catalunya en Comú
   forms:
     required_explanation: "* Los campos obligatorios están marcados con un asterisco"

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "i18n/tasks"
+
+describe "I18n sanity" do
+  let(:locales) do
+    ENV["ENFORCED_LOCALES"].presence || "en"
+  end
+
+  let(:i18n) { I18n::Tasks::BaseTask.new(locales: locales.split(",")) }
+  let(:non_normalized_paths) { i18n.non_normalized_paths }
+
+  unless ENV["SKIP_NORMALIZATION"]
+    it "is normalized" do
+      error_message = "The following files need to be normalized:\n" \
+                      "#{non_normalized_paths.map { |path| "  #{path}" }.join("\n")}\n" \
+                      "Please run `bundle exec i18n-tasks normalize --locales #{locales}` to fix them"
+
+      expect(non_normalized_paths).to be_empty, error_message
+    end
+  end
+end


### PR DESCRIPTION
Closes #28


- Replace "civicrm" in locales with "Catalunya en Comú"
- Remove unused english locale file
- Add spec for locale normalization
