### PR TITLE
allow visiting some paths in closed organizations

### DIFF
--- a/app/controllers/concerns/decidim/force_authentication_override.rb
+++ b/app/controllers/concerns/decidim/force_authentication_override.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ForceAuthenticationOverride
+    extend ActiveSupport::Concern
+
+    included do
+      private
+
+      # Check for all paths that should be allowed even if the user is not yet
+      # authorized
+      def allow_unauthorized_path?
+        return true if unauthorized_paths.any? { |path| /^#{path}/.match?(request.path) }
+
+        # allow homepage
+        return true if %w(/ /processes).include? request.path
+
+        # allow process groups
+        return true if %r{^/processes_groups}.match? request.path
+
+        false
+      end
+    end
+  end
+end

--- a/config/initializers/catencomu_overrides.rb
+++ b/config/initializers/catencomu_overrides.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  Decidim::ForceAuthentication.include(Decidim::ForceAuthenticationOverride)
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,4 +2,5 @@
 
 require "decidim/core/test/factories"
 require "decidim/proposals/test/factories"
+require "decidim/consultations/test/factories"
 require "decidim/decidim_awesome/test/factories"

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -12,7 +12,9 @@ checksums = [
       "/app/views/layouts/decidim/_main_footer.html.erb" => "a26a5a568485d84056f604ef013585a1", # centered organization logo
       "/app/views/decidim/account/show.html.erb" => "2e3c895104e03d7d092467a96f64703d", # blocks email editing
       "/app/views/decidim/devise/omniauth_registrations/new.html.erb" => "d32cbe7f5a60e2892fe3c8cb33b16cda", # blocks email editing
-      "/app/views/decidim/devise/sessions/new.html.erb" => "1da8569a34bcd014ffb5323c96391837" # adds link to civicrm signup
+      "/app/views/decidim/devise/sessions/new.html.erb" => "1da8569a34bcd014ffb5323c96391837", # adds link to civicrm signup
+      # concerns
+      "/app/controllers/concerns/decidim/force_authentication.rb" => "01567b679c74bd9999d4d1cd5647ef73"
     }
   },
   {

--- a/spec/system/dutyfree_areas_spec.rb
+++ b/spec/system/dutyfree_areas_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Free and private login areas", type: :system, perform_enqueued: true do
+  let(:organization) { create :organization, force_users_to_authenticate_before_access_organization: closed }
+  let(:closed) { true }
+  let!(:participatory_process) { create :participatory_process, organization: organization }
+  let!(:participatory_process_group) { create :participatory_process_group, :with_participatory_processes, organization: organization }
+  let!(:consultation) { create :consultation, :published, organization: organization }
+  let(:user) { nil }
+
+  before do
+    create :content_block, organization: organization, scope_name: :homepage, manifest_name: :hero
+    create :content_block, organization: organization, scope_name: :participatory_process_group_homepage, scoped_resource_id: participatory_process_group.id, manifest_name: :title
+
+    login_as user, scope: :user if user
+
+    switch_to_host(organization.host)
+  end
+
+  shared_examples "can visit duty free areas" do
+    it "allows visiting the homepage" do
+      visit decidim.root_path
+      expect_homepage
+    end
+
+    it "allows visiting processes landing page" do
+      visit decidim_participatory_processes.participatory_processes_path
+      expect_participatory_processes
+    end
+
+    it "allows visiting a process group" do
+      visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group.id)
+      expect_participatory_process_group
+    end
+
+    it "forbids visiting a process" do
+      visit decidim_participatory_processes.participatory_process_path(participatory_process.slug)
+      expect_sign_in
+    end
+
+    it "forbids visiting consultations" do
+      visit decidim_consultations.consultations_path
+      expect_sign_in
+    end
+
+    it "forbids visiting a consultation" do
+      visit decidim_consultations.consultation_path(consultation.slug)
+      expect_sign_in
+    end
+  end
+
+  shared_examples "can visit everything" do
+    it "allows visiting the homepage" do
+      visit decidim.root_path
+      expect_homepage
+    end
+
+    it "allows visiting processes groups" do
+      visit decidim_participatory_processes.participatory_processes_path
+      expect_participatory_processes
+    end
+
+    it "allows visiting a process" do
+      visit decidim_participatory_processes.participatory_process_path(participatory_process.slug)
+      expect_participatory_process
+    end
+
+    it "allows visiting a consultation" do
+      visit decidim_consultations.consultations_path
+      expect_consultations
+    end
+  end
+
+  context "when organization is closed" do
+    it_behaves_like "can visit duty free areas"
+
+    context "and user is logged" do
+      let(:user) { create :user, :confirmed, organization: organization }
+
+      it_behaves_like "can visit everything"
+    end
+  end
+
+  context "when organization is open" do
+    let(:closed) { false }
+
+    it_behaves_like "can visit everything"
+  end
+
+  def expect_homepage
+    expect(page).to have_content("Welcome to #{organization.name}")
+    expect(current_url).to match("/")
+  end
+
+  def expect_sign_in
+    expect(page).to have_content("Please, login with your account before access")
+    expect(current_url).to match("/users/sign_in")
+  end
+
+  def expect_participatory_processes
+    expect(page).to have_content(participatory_process.title["en"])
+    expect(current_url).to match("/processes")
+  end
+
+  def expect_participatory_process
+    expect(page).to have_content(participatory_process.title["en"])
+    expect(current_url).to match("/processes/#{participatory_process.slug}")
+  end
+
+  def expect_participatory_process_group
+    expect(page).to have_content(participatory_process_group.title["en"])
+    expect(current_url).to match("/processes_groups/#{participatory_process_group.id}")
+  end
+
+  def expect_consultations
+    expect(page).to have_content(consultation.title["en"])
+    expect(current_url).to match("/consultations")
+  end
+end


### PR DESCRIPTION
Allows non-logged users to visit certain pages in organization with `force_users_to_authenticate_before_access_organization` activated:

- [x] /
- [x] /processes
- [x] /processes_groups/*

closes #64 