### PR TITLE
Fix ungrouped processes index filters not working

### DIFF
--- a/app/views/decidim/participatory_processes/participatory_processes/index.js.erb
+++ b/app/views/decidim/participatory_processes/participatory_processes/index.js.erb
@@ -1,0 +1,6 @@
+var $grid = $('#processes-grid');
+var $loading = $grid.find('.loading');
+
+$grid.find('.card-grid').html('<%= j(render(collection)).strip.html_safe %>');
+$grid.find('.processes-grid-order-by').html('<%= j(render(partial: "decidim/participatory_processes/participatory_processes/order_by_processes", locals: { include_filter: true })).strip.html_safe %>');
+$loading.hide();


### PR DESCRIPTION
Closes #78 

After overriding the HTML view `app/views/decidim/participatory_processes/participatory_processes/index.html.erb`, the JS file was not being found `app/views/decidim/participatory_processes/participatory_processes/index.js.erb` and the HTML view was being rendered instead. The problem could be found in the logs.


- Before changes (see last line)

```bash
Started GET "/global_processes?filter%5Barea_id%5D=&filter%5Bdate%5D=past&filter%5Bscope_id%5D=" for ::1 at 2021-08-03 16:07:19 +0200
  Decidim::Organization Load (0.9ms)  SELECT  "decidim_organizations".* FROM "decidim_organizations" WHERE "decidim_organizations"."host" = $1 LIMIT $2  [["host", "localhost"], ["LIMIT", 1]]
  ↳ /home/ailobe/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/bundler/gems/decidim-f6522fe9dd4f/decidim-core/app/middleware/decidim/current_organization.rb:36
Processing by Decidim::ParticipatoryProcesses::ParticipatoryProcessesController#index as JS
  Parameters: {"filter"=>{"area_id"=>"", "date"=>"past", "scope_id"=>""}}
   (0.7ms)  SELECT CONCAT('/pages/', slug) FROM "decidim_static_pages" WHERE "decidim_static_pages"."decidim_organization_id" = $1 AND "decidim_static_pages"."allow_public_access" = $2 ORDER BY "decidim_static_pages"."weight" ASC  [["decidim_organization_id", 1], ["allow_public_access", true]]
  ↳ /home/ailobe/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/bundler/gems/decidim-f6522fe9dd4f/decidim-core/app/controllers/concerns/decidim/force_authentication.rb:44
  Decidim::ParticipatoryProcess Exists (0.7ms)  SELECT  1 AS one FROM "decidim_participatory_processes" WHERE "decidim_participatory_processes"."decidim_organization_id" = $1 AND "decidim_participatory_processes"."private_space" = $2 AND "decidim_participatory_processes"."published_at" IS NOT NULL AND "decidim_participatory_processes"."decidim_participatory_process_group_id" IS NULL AND "decidim_participatory_processes"."published_at" IS NOT NULL LIMIT $3  [["decidim_organization_id", 1], ["private_space", false], ["LIMIT", 1]]
  ↳ /home/ailobe/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/bundler/gems/decidim-f6522fe9dd4f/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb:23
===========
:public
:list
:process
[Decidim::ParticipatoryProcesses::Permissions, Decidim::Admin::Permissions, Decidim::Permissions]
===========
===========
:public
:list
:process_group
[Decidim::ParticipatoryProcesses::Permissions, Decidim::Admin::Permissions, Decidim::Permissions]
===========
  Rendering decidim/participatory_processes/participatory_processes/index.html.erb within layouts/decidim/application
```


- After changes (see last line) 

```
Started GET "/global_processes?filter%5Barea_id%5D=&filter%5Bdate%5D=past&filter%5Bscope_id%5D=" for ::1 at 2021-08-03 16:21:51 +0200
  Decidim::Organization Load (1.2ms)  SELECT  "decidim_organizations".* FROM "decidim_organizations" WHERE "decidim_organizations"."host" = $1 LIMIT $2  [["host", "localhost"], ["LIMIT", 1]]
  ↳ /home/ailobe/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/bundler/gems/decidim-f6522fe9dd4f/decidim-core/app/middleware/decidim/current_organization.rb:36
Processing by Decidim::ParticipatoryProcesses::ParticipatoryProcessesController#index as JS
  Parameters: {"filter"=>{"area_id"=>"", "date"=>"past", "scope_id"=>""}}
   (1.7ms)  SELECT CONCAT('/pages/', slug) FROM "decidim_static_pages" WHERE "decidim_static_pages"."decidim_organization_id" = $1 AND "decidim_static_pages"."allow_public_access" = $2 ORDER BY "decidim_static_pages"."weight" ASC  [["decidim_organization_id", 1], ["allow_public_access", true]]
  ↳ /home/ailobe/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/bundler/gems/decidim-f6522fe9dd4f/decidim-core/app/controllers/concerns/decidim/force_authentication.rb:44
  Decidim::ParticipatoryProcess Exists (1.4ms)  SELECT  1 AS one FROM "decidim_participatory_processes" WHERE "decidim_participatory_processes"."decidim_organization_id" = $1 AND "decidim_participatory_processes"."private_space" = $2 AND "decidim_participatory_processes"."published_at" IS NOT NULL AND "decidim_participatory_processes"."decidim_participatory_process_group_id" IS NULL AND "decidim_participatory_processes"."published_at" IS NOT NULL LIMIT $3  [["decidim_organization_id", 1], ["private_space", false], ["LIMIT", 1]]
  ↳ /home/ailobe/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/bundler/gems/decidim-f6522fe9dd4f/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb:23
===========
:public
:list
:process
[Decidim::ParticipatoryProcesses::Permissions, Decidim::Admin::Permissions, Decidim::Permissions]
===========
===========
:public
:list
:process_group
[Decidim::ParticipatoryProcesses::Permissions, Decidim::Admin::Permissions, Decidim::Permissions]
===========
  Rendering decidim/participatory_processes/participatory_processes/index.js.erb
```