### PR TITLE
Reorder meetings by start_time desc if not upcoming

### DIFF
--- a/app/controllers/concerns/meetings_controller_override.rb
+++ b/app/controllers/concerns/meetings_controller_override.rb
@@ -16,5 +16,9 @@ module MeetingsControllerOverride
         with_any_global_category: nil
       }
     end
+
+    def meetings
+      @meetings ||= paginate(search.result.order(start_time: :desc ))
+    end
   end
 end

--- a/app/controllers/concerns/meetings_controller_override.rb
+++ b/app/controllers/concerns/meetings_controller_override.rb
@@ -18,7 +18,8 @@ module MeetingsControllerOverride
     end
 
     def meetings
-      @meetings ||= paginate(search.result.order(start_time: :desc ))
+      is_upcoming_meetings = params.dig("filter", "with_any_date")&.include?("upcoming")
+      @meetings ||= paginate(search.result.order(start_time: is_upcoming_meetings ? :asc : :desc))
     end
   end
 end


### PR DESCRIPTION
Change the behaviour of the order of meetings when filtered.

By default it will show all meetings in desc order (meaning you will see the ones in the future, or closer to you if passed, and then the older ones). Only when set to see the "upcoming" meetings, they will be ordered first the closer ones and then ascend to the next in the future.